### PR TITLE
Value is a nullable return type

### DIFF
--- a/behavior-graph/build.gradle
+++ b/behavior-graph/build.gradle
@@ -42,7 +42,7 @@ import com.vanniktech.maven.publish.SonatypeHost
 mavenPublishing {
     configure(new KotlinJvm(new JavadocJar.Dokka("dokkaHtml"), true))
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-    coordinates("com.yahoo.behaviorgraph", "bgjvm", "0.8.0")
+    coordinates("com.yahoo.behaviorgraph", "bgjvm", "0.9.0")
     pom {
         name = 'Behavior Graph'
         description = 'Behavior Graph lets you build your programs out of small, easily understood pieces in a way that lets the computer do more of the work for you.'

--- a/behavior-graph/src/main/kotlin/behaviorgraph/TypedMoment.kt
+++ b/behavior-graph/src/main/kotlin/behaviorgraph/TypedMoment.kt
@@ -16,28 +16,18 @@ class TypedMoment<T> @JvmOverloads constructor(extent: Extent<*>, debugName: Str
 
     /**
      * Is there a current event and if the moment updated then what is the associated data.
-     * Otherwise throws an error.
+     * Will return null if the moment did not update this event.
+     * Be careful: It is possible that T is also an optional type itself
+     * So this typedMoment could be called with .update(null).
+     * In that case justUpdated will be true and value will also be null.
      * A behavior must demand this resource to access its value.
      */
     @get:JvmName("value")
-    val value: T
+    val value: T?
         get() {
             assertValidAccessor()
-            if (!_happened) { throw BehaviorGraphException("Cannot access moment value when it did not update.")
-            }
-            return this._happenedValue!!
+            return this._happenedValue
         }
-
-    /**
-     * Optional version value() property which may be more convenient.
-     * Returns T if justUpdated is true, null otherwise
-     * Be careful: It is possible that T is also an optional type itself
-     * So this typedMoment could be called with .update(null).
-     * In that case justUpdated will be true but justUpdatedValue would be null.
-     */
-    @get:JvmName("justUpdatedValue")
-    val justUpdatedValue: T?
-        get() = _happenedValue
 
     /**
      * If this Moment has ever been update what was the last Event it was updated.

--- a/behavior-graph/src/test/kotlin/behaviorgraph/MomentTest.kt
+++ b/behavior-graph/src/test/kotlin/behaviorgraph/MomentTest.kt
@@ -59,8 +59,8 @@ class MomentTest : AbstractBehaviorGraphTest() {
         // |> Then the data is visible in subsequent behaviors
         assertEquals(1, afterUpdate)
         assertTrue(updatedToOne)
-        // but is an Exception outside event loop
-        assertBehaviorGraphException { mr1.value }
+        // but null after event
+        assertNull(mr1.value)
     }
 
     @Test
@@ -81,19 +81,14 @@ class MomentTest : AbstractBehaviorGraphTest() {
     }
 
     @Test
-    fun `updatedValue returns optional wrapped value`() {
-        // In some cases justUpdatedValue may be easier to work with
-        // than checking for justUpdated and getting the value
-        // however kotlin collapses the nulls, so there's no notion of
-        // unwrapping as you might find in
+    fun `value is optional`() {
         val mr1: TypedMoment<String> = ext.typedMoment()
         val mr2: TypedMoment<String?> = ext.typedMoment()
 
         g.action {
             g.sideEffect {
-                // mr1 was not just updated, so justUpdatedValue is null
-                assertNull(mr1.justUpdatedValue)
-                var run = false
+                // mr1 was not just updated, so value is null
+                assertNull(mr1.value)
             }
         }
 
@@ -102,15 +97,15 @@ class MomentTest : AbstractBehaviorGraphTest() {
             mr2.update(null)
 
             g.sideEffect {
-                // mr1 was updated and it's value was hello so justUpdatedValue is hello
-                assertEquals("hello", mr1.justUpdatedValue)
+                // mr1 was updated, and it's value was hello so value is hello
+                assertEquals("hello", mr1.value)
                 // mr2 was also just updated, but with a value of null
                 assertTrue(mr2.justUpdated)
-                // however justUpdatedValue is null, so ?.let pattern will not run
+                assertNull(mr2.value)
+                // because is null, so ?.let pattern will not run
                 var run = false
-                mr2.justUpdatedValue?.let {
+                mr2.value?.let {
                     run = true
-                    assertNull(it)
                 }
                 assertFalse(run)
             }

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
     dependencies {
         // Build system
-        classpath 'com.android.tools.build:gradle:8.2.0'
+        classpath 'com.android.tools.build:gradle:8.5.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.9.20"
     }

--- a/example/src/main/kotlin/com/example/myapplication/ui/login/LoginExtent.kt
+++ b/example/src/main/kotlin/com/example/myapplication/ui/login/LoginExtent.kt
@@ -86,9 +86,9 @@ class LoginExtent(var loginActivityBG: LoginActivityBG, graph: Graph) : Extent<L
                     if (loggingIn.value) {
                         status = "Logging in...";
                     } else if (loggingIn.justUpdatedTo(false)) {
-                        if (loginComplete.justUpdated && loginComplete.value) {
+                        if (loginComplete.value == true) {
                             status = "Login Success";
-                        } else if (loginComplete.justUpdated && !loginComplete.value) {
+                        } else if (loginComplete.value == false) {
                             status = "Login Failed";
                         }
                     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Aug 23 11:41:29 PDT 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Previous forced unwrapping was throwing exception when updated value
was null.

* can accommodate null as a possible update value
* as well as null as an answer in case it wasn't updated

Changes to example code to accommodate more flexible value

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
