### PR TITLE
Make threadsafe

### DIFF
--- a/behavior-graph/build.gradle
+++ b/behavior-graph/build.gradle
@@ -75,4 +75,6 @@ mavenPublishing {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
+//    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0"
+//    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0"
 }

--- a/behavior-graph/src/main/kotlin/behaviorgraph/Action.kt
+++ b/behavior-graph/src/main/kotlin/behaviorgraph/Action.kt
@@ -3,6 +3,13 @@
 //
 package behaviorgraph
 
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Future
+import java.util.concurrent.Semaphore
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
 /**
  * An __Action__ is a block of code which initiates a Behavior Graph [Event].
  * You create actions with the [action], [actionAsync] methods on an [Extent].
@@ -14,18 +21,74 @@ interface Action {
     val debugName: String?
 }
 
-internal interface RunnableAction: Action {
-    fun runAction()
+abstract class RunnableAction: Action, Future<Nothing?> {
+    abstract fun runAction()
+    private val semaphore: Semaphore = Semaphore(0)
+    private var completed: Boolean = false
+    private var underlyingProblem: Throwable? = null
+
+    fun fail(underlyingProblem: Throwable) {
+        this.underlyingProblem = underlyingProblem
+        semaphore.release()
+    }
+
+    fun complete() {
+        if (!completed) {
+            completed = true
+            semaphore.release()
+        }
+    }
+
+    override fun cancel(p0: Boolean): Boolean {
+        return false
+    }
+
+    override fun isCancelled(): Boolean {
+        return false
+    }
+
+    override fun isDone(): Boolean {
+        return completed
+    }
+
+    override fun get(): Nothing? {
+        try {
+            semaphore.acquire()
+            if (underlyingProblem == null) {
+                return null
+            } else {
+                throw ExecutionException(underlyingProblem)
+            }
+        } finally {
+            semaphore.release()
+        }
+    }
+
+    override fun get(p0: Long, p1: TimeUnit): Nothing? {
+        if (semaphore.tryAcquire(p0, p1)) {
+            try {
+                if (underlyingProblem == null) {
+                    return null
+                } else {
+                    throw ExecutionException(underlyingProblem)
+                }
+            } finally {
+                semaphore.release()
+            }
+        } else {
+            throw TimeoutException()
+        }
+    }
 }
 
-internal class GraphAction(val thunk: Thunk, override val debugName: String? = null): RunnableAction {
+internal class GraphAction(val thunk: Thunk, override val debugName: String? = null): RunnableAction() {
     override fun runAction() {
         thunk.invoke()
     }
 }
 
 internal class ExtentAction<T>(val thunk: ExtentThunk<T>, val context: T, override val debugName: String? = null):
-    RunnableAction {
+    RunnableAction() {
     override fun runAction() {
         thunk.invoke(context)
     }

--- a/behavior-graph/src/main/kotlin/behaviorgraph/EventLoopState.kt
+++ b/behavior-graph/src/main/kotlin/behaviorgraph/EventLoopState.kt
@@ -1,6 +1,6 @@
 package behaviorgraph
 
-internal data class EventLoopState(val action: RunnableAction, val actionUpdates: MutableList<Resource> = mutableListOf(), var currentSideEffect: SideEffect? = null, var phase: EventLoopPhase = EventLoopPhase.Queued) {
+internal data class EventLoopState(val action: RunnableAction, val actionUpdates: MutableList<Resource> = mutableListOf(), var currentSideEffect: SideEffect? = null, var phase: EventLoopPhase = EventLoopPhase.Queued, var thread: Thread = Thread.currentThread()) {
     override fun toString(): String {
         var rows = mutableListOf<String>("Action")
         actionUpdates?.forEach { resource ->

--- a/behavior-graph/src/main/kotlin/behaviorgraph/Extent.kt
+++ b/behavior-graph/src/main/kotlin/behaviorgraph/Extent.kt
@@ -3,6 +3,8 @@
 //
 package behaviorgraph
 
+import java.util.concurrent.Future
+
 /**
  * An **Extent** is a collection of resources and behaviors. Extents allow us to
  * add (and remove) all those resources and behaviors to a graph at the same time.
@@ -94,8 +96,8 @@ open class Extent<ExtentContext: Any> @JvmOverloads constructor(val graph: Graph
      * Creates an Action on the graph and calls [addToGraph]
      */
     @JvmOverloads
-    fun addToGraphWithAction(debugName: String? = null) {
-        this.graph.action(debugName) {
+    fun addToGraphWithAction(debugName: String? = null): Future<*> {
+        return this.graph.action(debugName) {
             this.addToGraph()
         }
     }
@@ -216,21 +218,12 @@ open class Extent<ExtentContext: Any> @JvmOverloads constructor(val graph: Graph
     }
 
     /**
-     * Calls [Graph.actionAsync] on the Graph instance associated with this [Extent].
-     */
-    @JvmOverloads
-    fun actionAsync(debugName: String? = null, thunk: ExtentThunk<ExtentContext>) {
-        val action = ExtentAction(thunk, (context ?: this) as ExtentContext, debugName)
-        graph.asyncActionHelper(action)
-    }
-
-    /**
      * Calls [Graph.action] on the Graph instance associated with this [Extent].
      */
     @JvmOverloads
-    fun action(debugName: String? = null, thunk: ExtentThunk<ExtentContext>) {
+    fun action(debugName: String? = null, thunk: ExtentThunk<ExtentContext>): Future<*> {
         val action = ExtentAction(thunk, (context ?: this) as ExtentContext, debugName)
-        graph.actionHelper(action)
+        return graph.actionHelper(action)
     }
 
     override fun toString(): String {

--- a/behavior-graph/src/main/kotlin/behaviorgraph/Moment.kt
+++ b/behavior-graph/src/main/kotlin/behaviorgraph/Moment.kt
@@ -3,6 +3,8 @@
 //
 package behaviorgraph
 
+import java.util.concurrent.Future
+
 /**
  * A Moment is a type of resource is a type of Resource for tracking information that exists at a
  * single moment in time. A Button press is an example of a moment. It happens and then it is over.
@@ -53,8 +55,10 @@ class Moment @JvmOverloads constructor(extent: Extent<*>, debugName: String? = n
      * Create a new action and call [update].
      */
     @JvmOverloads
-    fun updateWithAction(debugName: String? = null) {
-        graph.action(debugName) { update() }
+    fun updateWithAction(debugName: String? = null): Future<*> {
+        return graph.action(debugName) {
+            update()
+        }
     }
 
     override fun clear() {

--- a/behavior-graph/src/main/kotlin/behaviorgraph/Resource.kt
+++ b/behavior-graph/src/main/kotlin/behaviorgraph/Resource.kt
@@ -47,6 +47,8 @@ open class Resource @JvmOverloads constructor(val extent: Extent<*>, var debugNa
 
     internal fun assertValidAccessor() {
         if (!graph.validateDependencies) { return }
+        // allow access to state from alternate threads while running
+        if (graph.eventLoopState != null && graph.eventLoopState!!.thread != Thread.currentThread()) { return }
         val currentBehavior = graph.currentBehavior
         if (currentBehavior != null && currentBehavior != suppliedBy && !(currentBehavior.demands?.contains(this) ?: false)) {
             throw BehaviorGraphException("Cannot access the value or event of a resource inside a behavior unless it is supplied or demanded.")

--- a/behavior-graph/src/main/kotlin/behaviorgraph/SideEffect.kt
+++ b/behavior-graph/src/main/kotlin/behaviorgraph/SideEffect.kt
@@ -12,20 +12,20 @@ interface SideEffect {
     val behavior: Behavior<*>?
 }
 
-internal interface RunnableSideEffect: SideEffect {
-    fun runSideEffect()
+internal interface RunnableSideEffect: SideEffect, Runnable {
 }
 
 internal class GraphSideEffect(val thunk: Thunk, override val behavior: Behavior<*>?, override val debugName: String?):
     RunnableSideEffect {
-    override fun runSideEffect() {
+
+    override fun run() {
         thunk.invoke()
     }
 }
 
 internal class ExtentSideEffect<T: Any>(val thunk: ExtentThunk<T>, val context: T, override val behavior: Behavior<T>?, override val debugName: String? = null):
     RunnableSideEffect {
-    override fun runSideEffect() {
+    override fun run() {
         thunk.invoke(context)
     }
 }

--- a/behavior-graph/src/main/kotlin/behaviorgraph/State.kt
+++ b/behavior-graph/src/main/kotlin/behaviorgraph/State.kt
@@ -4,6 +4,7 @@
 package behaviorgraph
 
 import behaviorgraph.Event.Companion.InitialEvent
+import java.util.concurrent.Future
 
 /**
  * A State is a type of resource for storing information over a period of time. Its value will persist into the future until it is updated.
@@ -62,8 +63,8 @@ class State<T> @JvmOverloads constructor(extent: Extent<*>, initialState: T, deb
      * Create a new action and call [update].
      */
     @JvmOverloads
-    fun updateWithAction(newValue: T, debugName: String? = null) {
-        graph.action(debugName, { update(newValue) })
+    fun updateWithAction(newValue: T, debugName: String? = null): Future<*> {
+        return graph.action(debugName, { update(newValue) })
     }
 
     /**

--- a/behavior-graph/src/test/kotlin/behaviorgraph/ConcurrencyTests.kt
+++ b/behavior-graph/src/test/kotlin/behaviorgraph/ConcurrencyTests.kt
@@ -1,0 +1,237 @@
+package behaviorgraph
+
+import kotlin.test.*
+import java.lang.Thread
+import java.util.concurrent.*
+
+class ConcurrencyTests : AbstractBehaviorGraphTest() {
+    @Test
+    fun runsOnActionThreadIfNotBusy() {
+        val sr1 = ext.state(1)
+        var runningThread: String? = null
+        val sem = Semaphore(0)
+        ext.behavior()
+            .demands(sr1)
+            .performs {
+                runningThread = Thread.currentThread().name
+                sem.release()
+            }
+        ext.addToGraphWithAction()
+
+        val t1 = Thread {
+            sr1.updateWithAction(2)
+        }
+        t1.name = "thisthread"
+        t1.start()
+        sem.acquire()
+        assertEquals("thisthread", runningThread)
+    }
+
+    @Test
+    fun secondThreadDispatchesAndContinuesWhileFirstIsBusy() {
+        // This test sets up two threads so the first can block
+        // the second, and we use the test running thread
+        // to orchestrate.
+        // The semaphores lead us through the steps so that we can
+        // test what we want.
+        val sem1 = Semaphore(0)
+        val sem2 = Semaphore(0)
+
+        val sr1 = ext.state(0)
+        val sr2 = ext.state(0)
+        ext.behavior()
+            .demands(sr1)
+            .performs {
+                sem1.release()
+                sem2.acquire()
+            }
+        ext.addToGraphWithAction()
+
+
+        var f1: Future<*>? = null
+        var f2: Future<*>? = null
+
+        val t1 = Thread {
+            f1 = sr1.updateWithAction(1)
+        }.start()
+        // first thread running bg (intentionally blocked in behavior)
+        sem1.acquire()
+
+        val t2 = Thread {
+            f2 = sr2.updateWithAction(2)
+            sem1.release()
+        }.start()
+        // thread 2 will be blocked and return a future
+        sem1.acquire()
+        assertFalse(f2!!.isDone) // still running
+        assertFalse(f2!!.cancel(true)) // fails to cancel
+        assertFalse(f2!!.isCancelled) // always false
+        // let t1 finish
+        sem2.release()
+        // now we can wait for t2 to finish with future
+        f2!!.get()
+        assertTrue(f2!!.isDone)
+        assertEquals(1, sr1.value)
+        assertEquals(2, sr2.value)
+    }
+
+    @Test
+    fun exceptionOnBackgroundThreadBubblesUpToFuture() {
+        // We have access to future in the thread that creates the action;
+        // however the exception may happen on the internally created background
+        // thread that ends up running the action if it blocks.
+        // This tests that this exception gets put into the Future which
+        // we throws when we call get() with pointer to the original exception.
+        //
+        // See note above about using multiple threads and semaphores
+        val sem1 = Semaphore(0)
+        val sem2 = Semaphore(0)
+
+        val sr1 = ext.state(0)
+        val sr2 = ext.state(0)
+        ext.behavior()
+            .demands(sr1)
+            .performs {
+                sem1.release()
+                sem2.acquire()
+            }
+        ext.addToGraphWithAction()
+
+
+        var f1: Future<*>? = null
+        var f2: Future<*>? = null
+
+        val t1 = Thread {
+            f1 = sr1.updateWithAction(1)
+        }.start()
+        // first thread running bg (intentionally blocked in behavior)
+        sem1.acquire()
+
+        val t2 = Thread {
+            f2 = ext.action {
+                // action inside action throws
+                // @SAL 10/16/2024-- I'm not sure if this is an annoying way to do this.
+                // This will hit an assert and throws which shows up in the console,
+                // but because it is in a background thread the other threads will continue.
+                ext.action { }
+            }
+            sem1.release()
+        }.start()
+        // thread 2 will be blocked and return a future
+        sem1.acquire()
+        sem2.release()
+
+        assertFails {
+            f2!!.get()
+        }
+    }
+
+    @Test
+    fun futureImplementsTimeout() {
+        // Calling get() with a timeout should throw an error if
+        // we don't unblock in time.
+        //
+        // See note above about using multiple threads and semaphores
+
+        val sem1 = Semaphore(0)
+        val sem2 = Semaphore(0)
+
+        val sr1 = ext.state(0)
+        val sr2 = ext.state(0)
+        ext.behavior()
+            .demands(sr1)
+            .performs {
+                sem1.release()
+                sem2.acquire()
+            }
+        ext.addToGraphWithAction()
+
+
+        var f1: Future<*>? = null
+        var f2: Future<*>? = null
+
+        val t1 = Thread {
+            f1 = sr1.updateWithAction(1)
+        }.start()
+        // first thread running bg (intentionally blocked in behavior)
+        sem1.acquire()
+
+        val t2 = Thread {
+            f2 = ext.action {
+            }
+            sem1.release()
+        }.start()
+        // thread 2 will be blocked and return a future
+        sem1.acquire()
+
+        // we don't unblock the first thread ever,
+        // so second action never runs
+        assertFails {
+            f2!!.get(100, TimeUnit.MILLISECONDS)
+        }
+    }
+
+    @Test
+    fun canAccessResourcesOnSecondThread() {
+        // |> Given we are in the middle of running an event
+        val sem = Semaphore(0)
+        val sem2 = Semaphore(0)
+        val sr1 = ext.state(1)
+        val sr2 = ext.state(2)
+        ext.behavior()
+            .demands(sr1)
+            .performs {
+                sem2.release()
+                sem.acquire()
+            }
+        ext.addToGraphWithAction()
+
+        val t1 = Thread {
+            sr1.updateWithAction(2)
+        }
+
+        t1.start()
+        sem2.acquire()
+
+
+        // |> When we access a resource from another thread
+        // |> Then we should be able to access the value without
+        // hitting an assert statement
+        var currentValue = 0
+        assertNoThrow {
+            currentValue = sr2.value
+        }
+        assertEquals(2, currentValue)
+    }
+
+    @Test
+    fun canRunSideEffectsOnSpecifiedThread() {
+        // |> Given we have provided an executor
+        g.sideEffectExecutor = Executors.newSingleThreadExecutor()
+
+        val sem = Semaphore(0)
+        val sr1 = ext.state(1)
+        var sideEffectThread: Thread? = null
+        ext.behavior()
+            .demands(sr1)
+            .performs {
+                it.sideEffect {
+                    sideEffectThread = Thread.currentThread()
+                    sem.release()
+                }
+            }
+        ext.addToGraphWithAction()
+
+        // |> When we run action from background thread
+        var backgroundThread: Thread? = null
+        Thread {
+            backgroundThread = Thread.currentThread()
+            sr1.updateWithAction(2)
+        }.start()
+        sem.acquire()
+
+        // |> Then Side effects still happen on main thread
+        assertNotEquals(sideEffectThread, backgroundThread)
+    }
+
+}

--- a/behavior-graph/src/test/kotlin/behaviorgraph/ExtentLifetimesTest.kt
+++ b/behavior-graph/src/test/kotlin/behaviorgraph/ExtentLifetimesTest.kt
@@ -435,7 +435,7 @@ class ExtentLifetimesTest : AbstractBehaviorGraphTest() {
 
         // |> When event compvales without having removed other member of unified
         // |> Then raise an error
-        assertBehaviorGraphException {
+        assertFails {
             ext1.addToGraphWithAction()
         }
     }
@@ -451,7 +451,7 @@ class ExtentLifetimesTest : AbstractBehaviorGraphTest() {
 
         // |> When event ends without removing child
         // |> Then raise an error
-        assertBehaviorGraphException {
+        assertFails {
             ext1.removeFromGraphWithAction()
         }
     }

--- a/behavior-graph/src/test/kotlin/behaviorgraph/ExtentTest.kt
+++ b/behavior-graph/src/test/kotlin/behaviorgraph/ExtentTest.kt
@@ -134,7 +134,7 @@ class ExtentTest : AbstractBehaviorGraphTest() {
                     it.extent.action {
                         assertEquals(it, nonSubclass)
                     }
-                    it.extent.actionAsync {
+                    it.extent.action {
                         assertEquals(it, nonSubclass)
                     }
                 }


### PR DESCRIPTION
* Actions are synchronized
* Actions return Futures which we can use to determine if they ran and to block
* Reentrant actions are now put at the end of the queue and not run immediately
* Actions from background thread are dispatched to another thread so they don't block
* All actions are essentially asyncAction, remove asyncAction api


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
