### PR TITLE
Switch from exceptions to asserts

### DIFF
--- a/behavior-graph/src/main/kotlin/behaviorgraph/AllDemandsMustBeAddedToTheGraphExceptions.kt
+++ b/behavior-graph/src/main/kotlin/behaviorgraph/AllDemandsMustBeAddedToTheGraphExceptions.kt
@@ -1,6 +1,0 @@
-//
-// Copyright Yahoo 2021
-//
-package behaviorgraph
-
-class AllDemandsMustBeAddedToTheGraphExceptions(s: String, val currentBehavior: Behavior<*>, val untrackedDemand: Resource) : BehaviorGraphException("$s Behavior=$currentBehavior untrackedDemand=$untrackedDemand")

--- a/behavior-graph/src/main/kotlin/behaviorgraph/BehaviorDependencyCycleDetectedException.kt
+++ b/behavior-graph/src/main/kotlin/behaviorgraph/BehaviorDependencyCycleDetectedException.kt
@@ -1,7 +1,0 @@
-//
-// Copyright Yahoo 2021
-//
-package behaviorgraph
-
-class BehaviorDependencyCycleDetectedException(s: String, val behavior: Behavior<*>, val cycle: List<Resource>) : BehaviorGraphException("$s Behavior=$behavior")
-

--- a/behavior-graph/src/main/kotlin/behaviorgraph/ChildLifetimeCannotBeParent.kt
+++ b/behavior-graph/src/main/kotlin/behaviorgraph/ChildLifetimeCannotBeParent.kt
@@ -1,3 +1,0 @@
-package behaviorgraph
-
-class ChildLifetimeCannotBeParent(val child: Extent<*>): BehaviorGraphException("Child lifetime cannot be a transitive parent.")

--- a/behavior-graph/src/main/kotlin/behaviorgraph/EventLoopPhase.kt
+++ b/behavior-graph/src/main/kotlin/behaviorgraph/EventLoopPhase.kt
@@ -4,5 +4,7 @@ internal enum class EventLoopPhase {
     Queued,
     Action,
     Updates,
-    SideEffects
+    SideEffects;
+
+    val processingChanges: Boolean get() = (this == Action || this == Updates)
 }

--- a/behavior-graph/src/main/kotlin/behaviorgraph/EventLoopState.kt
+++ b/behavior-graph/src/main/kotlin/behaviorgraph/EventLoopState.kt
@@ -8,4 +8,6 @@ internal data class EventLoopState(val action: RunnableAction, val actionUpdates
         }
         return rows.joinToString("\n")
     }
+
+    val runningOnCurrentThread: Boolean get() = this.thread == Thread.currentThread()
 }

--- a/behavior-graph/src/main/kotlin/behaviorgraph/Extent.kt
+++ b/behavior-graph/src/main/kotlin/behaviorgraph/Extent.kt
@@ -106,13 +106,15 @@ open class Extent<ExtentContext: Any> @JvmOverloads constructor(val graph: Graph
      * An extent must be added to the graph before any of its behaviors will run or any of its resources will be linked to.
      */
     fun addToGraph() {
-        if (graph.currentEvent != null) {
+        if (graph.processingChangesOnCurrentThread) {
             if (graph.automaticResourceNaming) {
                 nameResources()
             }
             graph.addExtent(this)
         } else {
-            throw BehaviorGraphException("addToGraph must be called within an event. Extent=$this")
+            assert(false) {
+                "addToGraph must be called within an event. \nAdding Extent=$this"
+            }
         }
     }
 
@@ -131,7 +133,7 @@ open class Extent<ExtentContext: Any> @JvmOverloads constructor(val graph: Graph
      */
     @JvmOverloads
     fun removeFromGraph(strategy: ExtentRemoveStrategy = ExtentRemoveStrategy.ExtentOnly) {
-        if (graph.currentEvent != null) {
+        if (graph.processingChangesOnCurrentThread) {
             if (addedToGraphWhen != null) {
                 if (strategy == ExtentRemoveStrategy.ExtentOnly || this.lifetime == null) {
                     graph.removeExtent(this)
@@ -140,7 +142,9 @@ open class Extent<ExtentContext: Any> @JvmOverloads constructor(val graph: Graph
                 }
             }
         } else {
-            throw BehaviorGraphException("removeFromGraph must be called within an event. Extent=$this")
+            assert(false) {
+                "removeFromGraph must be called within an event. \nRemoving Extent=$this"
+            }
         }
     }
 
@@ -227,7 +231,7 @@ open class Extent<ExtentContext: Any> @JvmOverloads constructor(val graph: Graph
     }
 
     override fun toString(): String {
-        return graph.toString()
+        return super.toString() + "\n" + graph.toString()
     }
 
 }

--- a/behavior-graph/src/main/kotlin/behaviorgraph/ExtentLifetime.kt
+++ b/behavior-graph/src/main/kotlin/behaviorgraph/ExtentLifetime.kt
@@ -23,8 +23,10 @@ internal class ExtentLifetime(
 
     fun unify(extent: Extent<*>) {
         if (extent.addedToGraphWhen != null) {
-            val err = SameLifetimeMustBeEstablishedBeforeAddingToGraph(extent)
-            throw err
+            assert(false) {
+                "Same lifetime relationship must be established before adding any extent to graph. \nExtent=$extent"
+            }
+            // disabled asserts just allows this
         }
         if (extent.lifetime != null) {
             // merge existing lifetimes and children into one lifetime heirarchy
@@ -55,8 +57,10 @@ internal class ExtentLifetime(
         while (myLifetime != null) {
             // check up the chain of parents to prevent circular lifetime
             if (myLifetime == lifetime) {
-                val err = BehaviorGraphException("Extent lifetime cannot be a child of itself")
-                throw err
+                assert(false) {
+                    "Extent lifetime cannot be a child of itself."
+                }
+                return
             }
             myLifetime = myLifetime.parent?.get()
         }

--- a/behavior-graph/src/main/kotlin/behaviorgraph/ExtentsCanOnlyBeAddedDuringAnEventException.kt
+++ b/behavior-graph/src/main/kotlin/behaviorgraph/ExtentsCanOnlyBeAddedDuringAnEventException.kt
@@ -1,7 +1,0 @@
-//
-// Copyright Yahoo 2021
-//
-package behaviorgraph
-
-class ExtentsCanOnlyBeAddedDuringAnEventException(s: String, val extent: Extent<*>) : BehaviorGraphException("$s Extent=$extent")
-

--- a/behavior-graph/src/main/kotlin/behaviorgraph/ExtentsCanOnlyBeRemovedDuringAnEventException.kt
+++ b/behavior-graph/src/main/kotlin/behaviorgraph/ExtentsCanOnlyBeRemovedDuringAnEventException.kt
@@ -1,7 +1,0 @@
-//
-// Copyright Yahoo 2021
-//
-package behaviorgraph
-
-class ExtentsCanOnlyBeRemovedDuringAnEventException(s: String, val extent: Extent<*>) : BehaviorGraphException("$s Extent=$extent")
-

--- a/behavior-graph/src/main/kotlin/behaviorgraph/MissingInitialValuesException.kt
+++ b/behavior-graph/src/main/kotlin/behaviorgraph/MissingInitialValuesException.kt
@@ -1,6 +1,0 @@
-//
-// Copyright Yahoo 2021
-//
-package behaviorgraph
-
-class MissingInitialValuesException(s: String, val resource: Resource) : BehaviorGraphException("$s Resource=$resource")

--- a/behavior-graph/src/main/kotlin/behaviorgraph/Resource.kt
+++ b/behavior-graph/src/main/kotlin/behaviorgraph/Resource.kt
@@ -32,16 +32,21 @@ open class Resource @JvmOverloads constructor(val extent: Extent<*>, var debugNa
     internal fun assertValidUpdater() {
         val currentBehavior = graph.currentBehavior
         val currentEvent = graph.currentEvent
-        if (currentBehavior == null && currentEvent == null) {
-            throw BehaviorGraphException("Resource $debugName must be updated inside a behavior or action")
+        if (!graph.processingChangesOnCurrentThread) {
+            assert(false) {
+                "Resource must be updated inside a behavior or action. \nResource=$this"
+            }
         }
         if (!graph.validateDependencies) { return }
         if (suppliedBy != null && currentBehavior != suppliedBy) {
-            throw BehaviorGraphException("Supplied resource $debugName can only be updated by its supplying behavior. CurrentBehavior = $currentBehavior")
-
+            assert(false) {
+                "Supplied resource can only be updated by its supplying behavior. \nResource=$this \nBehavior Trying to Update=$currentBehavior"
+            }
         }
         if (suppliedBy == null && currentBehavior != null) {
-            throw BehaviorGraphException("Unsupplied resource $debugName can only be updated in an action. CurrentBehavior=$currentBehavior")
+            assert(false) {
+                "Unsupplied resource can only be updated in an action. \nResource=$this \nBehaviorTrying to Update=$currentBehavior"
+            }
         }
     }
 
@@ -51,7 +56,9 @@ open class Resource @JvmOverloads constructor(val extent: Extent<*>, var debugNa
         if (graph.eventLoopState != null && graph.eventLoopState!!.thread != Thread.currentThread()) { return }
         val currentBehavior = graph.currentBehavior
         if (currentBehavior != null && currentBehavior != suppliedBy && !(currentBehavior.demands?.contains(this) ?: false)) {
-            throw BehaviorGraphException("Cannot access the value or event of a resource inside a behavior unless it is supplied or demanded.")
+            assert(false) {
+                "Cannot access the value or event of a resource inside a behavior unless it is supplied or demanded. \nResource=$this \nAccessing Behavior=$currentBehavior"
+            }
         }
     }
 

--- a/behavior-graph/src/main/kotlin/behaviorgraph/ResourceCannotBeSuppliedByMoreThanOneBehaviorException.kt
+++ b/behavior-graph/src/main/kotlin/behaviorgraph/ResourceCannotBeSuppliedByMoreThanOneBehaviorException.kt
@@ -1,6 +1,0 @@
-//
-// Copyright Yahoo 2021
-//
-package behaviorgraph
-
-class ResourceCannotBeSuppliedByMoreThanOneBehaviorException(s: String, val alreadySupplied: Resource, val desiredSupplier: Behavior<*>) : BehaviorGraphException("$s alreadySupplied=$alreadySupplied desiredSupplier=$desiredSupplier")

--- a/behavior-graph/src/main/kotlin/behaviorgraph/SameLifetimeMustBeEstablishedBeforeAddingToGraph.kt
+++ b/behavior-graph/src/main/kotlin/behaviorgraph/SameLifetimeMustBeEstablishedBeforeAddingToGraph.kt
@@ -1,3 +1,0 @@
-package behaviorgraph
-
-class SameLifetimeMustBeEstablishedBeforeAddingToGraph(val ext: Extent<*>): BehaviorGraphException("Same lifetime relationship must be established before adding any extent to graph.")

--- a/behavior-graph/src/main/kotlin/behaviorgraph/TypedMoment.kt
+++ b/behavior-graph/src/main/kotlin/behaviorgraph/TypedMoment.kt
@@ -68,7 +68,7 @@ class TypedMoment<T> @JvmOverloads constructor(extent: Extent<*>, debugName: Str
     }
 
     override fun toString(): String {
-        return String.format("%s (tm) == %s (%s)", debugName ?: "resource", if (_happened) _happenedValue else "NA", event?.sequence)
+        return String.format("%s (tm) == %s (%s)", debugName ?: "resource", if (_happened) _happenedValue else "NA", _happenedWhen?.sequence)
     }
 
     /**

--- a/behavior-graph/src/test/kotlin/behaviorgraph/AbstractBehaviorGraphTest.kt
+++ b/behavior-graph/src/test/kotlin/behaviorgraph/AbstractBehaviorGraphTest.kt
@@ -17,14 +17,6 @@ abstract class AbstractBehaviorGraphTest
     lateinit var r_a: State<Long>
     lateinit var r_b: State<Long>
     lateinit var r_c: State<Long>
-    protected fun assertBehaviorGraphException(lambda: () -> Unit) {
-        try {
-            lambda()
-        } catch (e: BehaviorGraphException) {
-            return
-        }
-        fail("did not catch expected BehaviorGraphException")
-    }
 
     /**
      * Usage: assertExpectedException(Exception::class) {...lambda to run}

--- a/behavior-graph/src/test/kotlin/behaviorgraph/DynamicGraphChangesTest.kt
+++ b/behavior-graph/src/test/kotlin/behaviorgraph/DynamicGraphChangesTest.kt
@@ -442,7 +442,7 @@ class DynamicGraphChangesTest : AbstractBehaviorGraphTest() {
 
         // |> When behavior activated before relink is activated
         // |> Then action should throw because behavior does not supply that resource
-        assertBehaviorGraphException {
+        assertFails {
             m1.update()  // cannot update unsupplied resource
         }
 
@@ -628,7 +628,7 @@ class DynamicGraphChangesTest : AbstractBehaviorGraphTest() {
         ext2.behavior().dynamicDemands(ext2.didAdd) { _, demands -> demands.add(r1) }.runs {}
         // |> When that extent is added
         // |> Then it should raise an error
-        assertBehaviorGraphException {
+        assertFails {
             ext2.addToGraphWithAction()
         }
     }

--- a/behavior-graph/src/test/kotlin/behaviorgraph/EffectsActionsEventsTest.kt
+++ b/behavior-graph/src/test/kotlin/behaviorgraph/EffectsActionsEventsTest.kt
@@ -207,7 +207,7 @@ class EffectsActionsEventsTest : AbstractBehaviorGraphTest() {
     @Test
     fun `effects can only be run during an event`() {
         ext.addToGraphWithAction()
-        assertBehaviorGraphException {
+        assertFails {
             ext.sideEffect {  }
         }
     }
@@ -378,7 +378,7 @@ class EffectsActionsEventsTest : AbstractBehaviorGraphTest() {
 
     @Test
     fun `sideEffect in sideEffect doesnt make sense`() {
-        assertBehaviorGraphException {
+        assertFails {
             g.action {
                 g.sideEffect {
                     g.sideEffect {

--- a/behavior-graph/src/test/kotlin/behaviorgraph/ExtentLifetimesTest.kt
+++ b/behavior-graph/src/test/kotlin/behaviorgraph/ExtentLifetimesTest.kt
@@ -42,7 +42,7 @@ class ExtentLifetimesTest : AbstractBehaviorGraphTest() {
 
         // |> When unified after adding one extent
         // |> Then it will throw an error
-        assertBehaviorGraphException {
+        assertFails {
             g.action {
                 ext1.addToGraph()
                 ext2.unifyLifetime(ext1)
@@ -108,7 +108,7 @@ class ExtentLifetimesTest : AbstractBehaviorGraphTest() {
 
         // |> When they are added
         // |> Then it should raise an error
-        assertBehaviorGraphException {
+        assertFails {
             g.action {
                 ext1.addToGraph()
                 ext2.addToGraph()
@@ -128,7 +128,7 @@ class ExtentLifetimesTest : AbstractBehaviorGraphTest() {
 
         // |> When they are both added
         // |> Then it should raise an error
-        assertBehaviorGraphException {
+        assertFails {
             g.action {
                 ext1.addToGraph()
                 ext2.addToGraph()
@@ -165,7 +165,7 @@ class ExtentLifetimesTest : AbstractBehaviorGraphTest() {
 
         // |> When child is added first
         // |> Then it should raise an error
-        assertBehaviorGraphException {
+        assertFails {
             ext2.addToGraphWithAction()
         }
     }
@@ -234,7 +234,7 @@ class ExtentLifetimesTest : AbstractBehaviorGraphTest() {
 
         // |> When they are added
         // |> Then it should raise an error
-        assertBehaviorGraphException {
+        assertFails {
             g.action {
                 ext1.addToGraph()
                 ext2.addToGraph()
@@ -253,7 +253,7 @@ class ExtentLifetimesTest : AbstractBehaviorGraphTest() {
 
         // |> When they are added
         // |> Then it should raise an error
-        assertBehaviorGraphException {
+        assertFails {
             g.action {
                 ext1.addToGraph()
                 ext2.addToGraph()
@@ -313,7 +313,7 @@ class ExtentLifetimesTest : AbstractBehaviorGraphTest() {
 
         // |> When we try to set reverse relationship
         // |> Then raise an error
-        assertBehaviorGraphException {
+        assertFails {
             ext2.addChildLifetime(ext1)
         }
     }
@@ -329,7 +329,7 @@ class ExtentLifetimesTest : AbstractBehaviorGraphTest() {
 
         // |> When that unified tries to become parent
         // |> Then raise an error
-        assertBehaviorGraphException {
+        assertFails {
             ext3.addChildLifetime(ext1)
         }
     }
@@ -344,7 +344,7 @@ class ExtentLifetimesTest : AbstractBehaviorGraphTest() {
         ext3.addChildLifetime(ext1)
         // |> When parent becomes unified with child
         // |> Then raise an error
-        assertBehaviorGraphException {
+        assertFails {
             ext1.unifyLifetime(ext2)
         }
     }
@@ -472,7 +472,7 @@ class ExtentLifetimesTest : AbstractBehaviorGraphTest() {
 
         // |> When one extent is removed without fixing the dynamicDemand to that extent
         // |> Then raise an error
-        assertBehaviorGraphException {
+        assertFails {
             ext2.removeFromGraphWithAction()
         }
     }
@@ -493,7 +493,7 @@ class ExtentLifetimesTest : AbstractBehaviorGraphTest() {
 
         // |> When one extent is removed without fixing the dynamicSupply to that extent
         // |> Then raise an error
-        assertBehaviorGraphException {
+        assertFails {
             ext2.removeFromGraphWithAction()
         }
     }

--- a/behavior-graph/src/test/kotlin/behaviorgraph/ExtentTest.kt
+++ b/behavior-graph/src/test/kotlin/behaviorgraph/ExtentTest.kt
@@ -77,13 +77,13 @@ class ExtentTest : AbstractBehaviorGraphTest() {
     //checks below
     @Test
     fun `check cannot add extent to graph multiple times`() {
-        assertBehaviorGraphException { setupExt.addToGraphWithAction() }
+        assertFails { setupExt.addToGraphWithAction() }
     }
 
     @Test
     fun `check extent cannot be added to graph outside event`() {
         val e = TestExtentLocal(g)
-        assertBehaviorGraphException {
+        assertFails {
             e.addToGraph()
         }
     }
@@ -92,7 +92,7 @@ class ExtentTest : AbstractBehaviorGraphTest() {
     fun `check extent cannot be removed from graph outside event`() {
         val e = TestExtentLocal(g)
         e.addToGraphWithAction()
-        assertBehaviorGraphException {
+        assertFails {
             e.removeFromGraph()
         }
     }

--- a/behavior-graph/src/test/kotlin/behaviorgraph/GraphCheckTests.kt
+++ b/behavior-graph/src/test/kotlin/behaviorgraph/GraphCheckTests.kt
@@ -27,12 +27,12 @@ class GraphCheckTests : AbstractBehaviorGraphTest() {
         var caught = false
         try {
             ext.addToGraphWithAction()
-        } catch (e: BehaviorDependencyCycleDetectedException) {
+        } catch (e: AssertionError) {
             caught = true
-            val cycle = e.cycle
-            assertEquals(2, cycle.size)
-            assertSame(r_x, cycle[0])
-            assertSame(r_y, cycle[1])
+            //val cycle = e.cycle
+            //assertEquals(2, cycle.size)
+            //assertSame(r_x, cycle[0])
+            //assertSame(r_y, cycle[1])
         }
         assertTrue(caught)
     }
@@ -48,7 +48,7 @@ class GraphCheckTests : AbstractBehaviorGraphTest() {
             .supplies(r_x)
             .demands(r_a)
             .runs {}
-        assertBehaviorGraphException { ext.addToGraphWithAction() }
+        assertFails { ext.addToGraphWithAction() }
     }
 
     @Test
@@ -59,11 +59,11 @@ class GraphCheckTests : AbstractBehaviorGraphTest() {
             .runs {}
         ext.addToGraphWithAction()
 
-        assertBehaviorGraphException {
+        assertFails {
             b_x.setDynamicDemands(listOf(r_a))
         }
 
-        assertBehaviorGraphException {
+        assertFails {
             b_x.setDynamicSupplies(listOf(r_b))
         }
     }
@@ -75,13 +75,13 @@ class GraphCheckTests : AbstractBehaviorGraphTest() {
             .demands()
             .runs {}
 
-        assertBehaviorGraphException {
+        assertFails {
             g.action("update") {
                 b_x.setDynamicDemands(listOf(r_a))
             }
         }
 
-        assertBehaviorGraphException {
+        assertFails {
             g.action("update") {
                 b_x.setDynamicSupplies(listOf(r_a))
             }
@@ -185,7 +185,7 @@ class GraphCheckTests : AbstractBehaviorGraphTest() {
         ext.behavior().demands(mr1).runs {
 
         }
-        assertBehaviorGraphException {
+        assertFails {
             ext.addToGraphWithAction()
         }
     }

--- a/behavior-graph/src/test/kotlin/behaviorgraph/MomentTest.kt
+++ b/behavior-graph/src/test/kotlin/behaviorgraph/MomentTest.kt
@@ -119,7 +119,7 @@ class MomentTest : AbstractBehaviorGraphTest() {
         val mr1 = ext.moment("mr1")
         // |> When it is updated
         // |> Then an error is raised
-        assertBehaviorGraphException { mr1.update() }
+        assertFails { mr1.update() }
     }
 
     @Test
@@ -141,7 +141,7 @@ class MomentTest : AbstractBehaviorGraphTest() {
 
         // |> When it is updated by the wrong behavior
         // |> Then it should throw
-        assertBehaviorGraphException { mr1.update() }
+        assertFails { mr1.update() }
     }
 
     @Test
@@ -161,14 +161,14 @@ class MomentTest : AbstractBehaviorGraphTest() {
 
         // |> When it is updated by the wrong behavior
         // |> Then it should throw
-        assertBehaviorGraphException { mr1.update() }
+        assertFails { mr1.update() }
     }
 
     @Test
     fun `check moment happens outside event loop is an error`() {
         val mr1 = ext.moment("mr1")
         ext.addToGraphWithAction()
-        assertBehaviorGraphException { mr1.update() }
+        assertFails { mr1.update() }
     }
 
     @Test
@@ -221,19 +221,19 @@ class MomentTest : AbstractBehaviorGraphTest() {
         ext2.addToGraphWithAction()
 
         // |> Then it will fail
-        assertBehaviorGraphException {
+        assertFails {
             mr3.updateWithAction()
         }
-        assertBehaviorGraphException {
+        assertFails {
             mr4.updateWithAction()
         }
-        assertBehaviorGraphException {
+        assertFails {
             mr5.updateWithAction()
         }
 
         // |> And when we access a supplied resource from an action
         // |> Then it will fail
-        assertBehaviorGraphException {
+        assertFails {
             mr2.updateWithAction(2)
         }
     }

--- a/behavior-graph/src/test/kotlin/behaviorgraph/StateTest.kt
+++ b/behavior-graph/src/test/kotlin/behaviorgraph/StateTest.kt
@@ -256,7 +256,7 @@ class StateTest : AbstractBehaviorGraphTest() {
 
         // |> When it is updated by the wrong behavior
         // |> Then it should throw
-        assertBehaviorGraphException { mr1.update() }
+        assertFails { mr1.update() }
     }
 
     @Test
@@ -273,14 +273,14 @@ class StateTest : AbstractBehaviorGraphTest() {
 
         // |> When it is updated by a behavior
         // |> Then it should throw
-        assertBehaviorGraphException { mr1.update() }
+        assertFails { mr1.update() }
     }
 
     @Test
     fun `check update outside event is an error`() {
         val sr1 = ext.state<Long>(0, "mr1")
         ext.addToGraphWithAction()
-        assertBehaviorGraphException { sr1.update(2) }
+        assertFails { sr1.update(2) }
     }
 
     @Test
@@ -295,7 +295,7 @@ class StateTest : AbstractBehaviorGraphTest() {
         }
         ext.addToGraphWithAction();
 
-        assertBehaviorGraphException {
+        assertFails {
             mr1.updateWithAction()
         }
     }
@@ -309,7 +309,7 @@ class StateTest : AbstractBehaviorGraphTest() {
         }
         ext.addToGraphWithAction()
 
-        assertBehaviorGraphException {
+        assertFails {
             mr1.update()
         }
     }
@@ -369,21 +369,21 @@ class StateTest : AbstractBehaviorGraphTest() {
         ext2.addToGraphWithAction();
 
         // |> Then it will fail
-        assertBehaviorGraphException {
+        assertFails {
             sr3.updateWithAction(2)
         }
 
-        assertBehaviorGraphException {
+        assertFails {
             sr4.updateWithAction(2)
         }
 
-        assertBehaviorGraphException {
+        assertFails {
             sr5.updateWithAction(2)
         }
 
         // |> And when we access a supplied resource from an action
         // |> Then it will fail
-        assertBehaviorGraphException {
+        assertFails {
             sr2.updateWithAction(2)
         }
     }


### PR DESCRIPTION
Asserts are disabled in production so won't create the errors that were meant to help developers.

* fix some checks to also consider which thread event is running on


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
