### PR TITLE
Fix Resource format strings

### DIFF
--- a/behavior-graph/src/main/kotlin/behaviorgraph/Moment.kt
+++ b/behavior-graph/src/main/kotlin/behaviorgraph/Moment.kt
@@ -66,7 +66,7 @@ class Moment @JvmOverloads constructor(extent: Extent<*>, debugName: String? = n
     }
 
     override fun toString(): String {
-        return String.format("%s (m) == %s (%s)", debugName ?: "resource", if (_happened) "Updated" else "Not Updated", event?.sequence)
+        return String.format("%s %s == %s (%s)", debugName ?: "", super.toString(), if (_happened) "Updated" else "Not Updated", _happenedWhen?.sequence)
     }
 
 }

--- a/behavior-graph/src/main/kotlin/behaviorgraph/Resource.kt
+++ b/behavior-graph/src/main/kotlin/behaviorgraph/Resource.kt
@@ -61,8 +61,4 @@ open class Resource @JvmOverloads constructor(val extent: Extent<*>, var debugNa
             }
         }
     }
-
-    override fun toString(): String {
-        return String.format("%s (r)", debugName ?: "resource")
-    }
 }

--- a/behavior-graph/src/main/kotlin/behaviorgraph/State.kt
+++ b/behavior-graph/src/main/kotlin/behaviorgraph/State.kt
@@ -139,7 +139,7 @@ class State<T> @JvmOverloads constructor(extent: Extent<*>, initialState: T, deb
     }
 
     override fun toString(): String {
-        return String.format("%s (s) == %s (%s)", debugName ?: "resource", currentState.value, currentState.event.sequence)
+        return String.format("%s %s == %s (%s)", debugName ?: "", super.toString(), currentState.value, currentState.event.sequence)
     }
 
     private data class StateHistory<T>(val value: T, val event: Event)

--- a/behavior-graph/src/main/kotlin/behaviorgraph/TypedMoment.kt
+++ b/behavior-graph/src/main/kotlin/behaviorgraph/TypedMoment.kt
@@ -68,7 +68,7 @@ class TypedMoment<T> @JvmOverloads constructor(extent: Extent<*>, debugName: Str
     }
 
     override fun toString(): String {
-        return String.format("%s (tm) == %s (%s)", debugName ?: "resource", if (_happened) _happenedValue else "NA", _happenedWhen?.sequence)
+        return String.format("%s %s == %s (%s)", debugName ?: "", super.toString(), if (_happened) _happenedValue else "NA", _happenedWhen?.sequence)
     }
 
     /**

--- a/behavior-graph/src/test/kotlin/behaviorgraph/DependenciesTest.kt
+++ b/behavior-graph/src/test/kotlin/behaviorgraph/DependenciesTest.kt
@@ -102,4 +102,44 @@ class DependenciesTest : AbstractBehaviorGraphTest() {
 
         assertEquals(33L, parent_r2.value)
     }
+
+    @Test
+    fun toStringWorksInBehaviorsThatDontDemandMentionedResources() {
+        // We want to be able to debug things
+        // So toString methods shouldn't trigger any demand verification checks
+
+        val s1 = ext.state(0)
+        val m1 = ext.moment()
+        val tm1 = ext.typedMoment<Int>()
+        val m2 = ext.moment()
+
+        ext.behavior()
+            .demands(s1)
+            .supplies(m2)
+            .performs {
+                m2.update()
+            }
+
+        var s1_string = ""
+        var m1_string = ""
+        var tm1_string = ""
+        ext.behavior()
+            .demands(m2)
+            .performs {
+                s1_string = s1.toString()
+                m1_string = m1.toString()
+                tm1_string = tm1.toString()
+            }
+
+        ext.addToGraphWithAction()
+        ext.action {
+            s1.update(1)
+            m1.update()
+            tm1.update(1)
+        }
+
+        assert(s1_string.isNotEmpty())
+        assert(m1_string.isNotEmpty())
+        assert(tm1_string.isNotEmpty())
+    }
 }


### PR DESCRIPTION
* include object id
* moment doesn't use event which triggers valid accessor check
* add test that can call toString without needing to demand resource


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
